### PR TITLE
[SASS-FeatureSwitchLibrary] Add Feature Switch Library for dynamic switching locally and in environments

### DIFF
--- a/app/actions/AuthorisedAction.scala
+++ b/app/actions/AuthorisedAction.scala
@@ -17,6 +17,7 @@
 package actions
 
 import config.AppConfig
+import featureswitch.core.config.EmaSupportingAgent
 import models.User
 import models.authorisation.DelegatedAuthRules
 import models.authorisation.Enrolment.{Agent, Individual, Nino, SupportingAgent}
@@ -122,7 +123,7 @@ class AuthorisedAction @Inject()(defaultActionBuilder: DefaultActionBuilder,
       val logMessage = s"$agentAuthLogString - No active session."
       logger.info(logMessage)
       unauthorized
-    case _: AuthorisationException if appConfig.emaSupportingAgentsEnabled =>
+    case _: AuthorisationException if appConfig.isEnabled(EmaSupportingAgent) =>
       authorised(secondaryAgentPredicate(mtdItId))
         .retrieve(allEnrolments)(
           enrolments => handleForValidAgent(block, mtdItId, enrolments, isSupportingAgent = true)

--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -17,6 +17,7 @@
 package config
 
 import com.google.inject.ImplementedBy
+import featureswitch.core.config.FeatureSwitching
 import play.api.Configuration
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
@@ -24,7 +25,7 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.duration.Duration
 
 @ImplementedBy(classOf[AppConfigImpl])
-trait AppConfig {
+trait AppConfig extends FeatureSwitching {
   def ifBaseUrl: String
   def ifEnvironment: String
   def authorisationTokenFor(apiVersion: String): String
@@ -34,9 +35,8 @@ trait AppConfig {
   def desAuthorisationToken: String
   def encryptionKey: String
   def mongoJourneyAnswersTTL: Int
-  def emaSupportingAgentsEnabled: Boolean
-  def sectionCompletedQuestionEnabled: Boolean
   def replaceJourneyAnswersIndexes: Boolean
+  def getFeatureSwitchValue(feature: String): Boolean
 }
 
 @Singleton
@@ -59,7 +59,6 @@ class AppConfigImpl @Inject()(config: Configuration, servicesConfig: ServicesCon
   def desBaseUrl: String = servicesConfig.baseUrl("des")
   def desEnvironment: String = config.get[String]("microservice.services.des.environment")
   def desAuthorisationToken: String = config.get[String]("microservice.services.des.authorisation-token")
-  
-  def emaSupportingAgentsEnabled: Boolean = config.get[Boolean]("feature-switch.ema-supporting-agents-enabled")
-  def sectionCompletedQuestionEnabled: Boolean = config.get[Boolean]("feature-switch.sectionCompletedQuestionEnabled")
+
+  def getFeatureSwitchValue(feature: String): Boolean = servicesConfig.getBoolean(feature)
 }

--- a/app/featureswitch/api/controllers/FeatureSwitchApiController.scala
+++ b/app/featureswitch/api/controllers/FeatureSwitchApiController.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package featureswitch.api.controllers
+
+import featureswitch.api.services.FeatureSwitchService
+import featureswitch.core.models.FeatureSwitchSetting
+import play.api.libs.json.Json
+import play.api.mvc.{Action, AnyContent, InjectedController}
+
+import javax.inject.{Inject, Singleton}
+
+@Singleton
+class FeatureSwitchApiController @Inject()(featureSwitchService: FeatureSwitchService) extends InjectedController {
+
+  def getFeatureSwitches: Action[AnyContent] = Action {
+    Ok(Json.toJson(featureSwitchService.getFeatureSwitches()))
+  }
+
+  def updateFeatureSwitches(): Action[Seq[FeatureSwitchSetting]] = Action(parse.json[Seq[FeatureSwitchSetting]]) {
+    req =>
+      val updatedFeatureSwitches = featureSwitchService.updateFeatureSwitches(req.body)
+      Ok(Json.toJson(updatedFeatureSwitches))
+  }
+
+}

--- a/app/featureswitch/api/services/FeatureSwitchService.scala
+++ b/app/featureswitch/api/services/FeatureSwitchService.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package featureswitch.api.services
+
+import config.AppConfig
+import featureswitch.core.config.FeatureSwitchRegistry
+import featureswitch.core.models.FeatureSwitchSetting
+
+import javax.inject.{Inject, Singleton}
+
+@Singleton
+class FeatureSwitchService @Inject()(featureSwitchRegistry: FeatureSwitchRegistry,
+                                     val config: AppConfig) {
+
+  def getFeatureSwitches(): Seq[FeatureSwitchSetting] =
+    featureSwitchRegistry.switches.map(
+      switch =>
+        FeatureSwitchSetting(
+          switch.configName,
+          switch.displayName,
+          config.isEnabled(switch)
+        )
+    )
+
+  def updateFeatureSwitches(updatedFeatureSwitches: Seq[FeatureSwitchSetting]): Seq[FeatureSwitchSetting] = {
+    updatedFeatureSwitches.foreach(
+      featureSwitchSetting =>
+        featureSwitchRegistry.get(featureSwitchSetting.configName).foreach {
+          featureSwitch =>
+            if (featureSwitchSetting.isEnabled) config.enable(featureSwitch) else config.disable(featureSwitch)
+        }
+    )
+
+    getFeatureSwitches()
+  }
+}

--- a/app/featureswitch/core/config/FeatureSwitchRegistry.scala
+++ b/app/featureswitch/core/config/FeatureSwitchRegistry.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package featureswitch.core.config
+
+import featureswitch.core.models.FeatureSwitch
+
+trait FeatureSwitchRegistry {
+
+  def switches: Seq[FeatureSwitch]
+
+  def apply(name: String): FeatureSwitch =
+    get(name) match {
+      case Some(switch) => switch
+      case None => throw new IllegalArgumentException("Invalid feature switch: " + name)
+    }
+
+  def get(name: String): Option[FeatureSwitch] = switches find (_.configName == name)
+
+}

--- a/app/featureswitch/core/config/FeatureSwitching.scala
+++ b/app/featureswitch/core/config/FeatureSwitching.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package featureswitch.core.config
+
+import config.AppConfig
+import featureswitch.core.models.FeatureSwitch
+import play.api.Logging
+
+trait FeatureSwitching extends Logging { config: AppConfig =>
+
+  def isEnabled(featureSwitch: FeatureSwitch): Boolean =
+    sys.props get featureSwitch.configName match {
+      case Some(value) => value.toBoolean
+      case None => config.getFeatureSwitchValue(featureSwitch.configName)
+    }
+
+  def enable(featureSwitch: FeatureSwitch): Unit = {
+    logger.warn(s"[enable] $featureSwitch")
+    sys.props += featureSwitch.configName -> true.toString
+  }
+
+  def disable(featureSwitch: FeatureSwitch): Unit = {
+    logger.warn(s"[disable] $featureSwitch")
+    sys.props += featureSwitch.configName -> false.toString
+  }
+}

--- a/app/featureswitch/core/config/FeatureSwitchingModule.scala
+++ b/app/featureswitch/core/config/FeatureSwitchingModule.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package featureswitch.core.config
+
+import play.api.inject.{Binding, Module}
+import play.api.{Configuration, Environment}
+import featureswitch.core.models.FeatureSwitch
+
+import javax.inject.Singleton
+
+@Singleton
+class FeatureSwitchingModule extends Module with FeatureSwitchRegistry {
+
+  val switches: Seq[FeatureSwitch] = Seq(
+    SectionCompletedQuestion,
+    EmaSupportingAgent
+  )
+
+  override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
+    Seq(
+      bind[FeatureSwitchRegistry].to(this).eagerly()
+    )
+  }
+
+}
+
+case object SectionCompletedQuestion extends FeatureSwitch {
+  override val configName: String  = prefix + "sectionCompletedQuestionEnabled"
+  override val displayName: String = "Section Completed Question enabled"
+}
+
+case object EmaSupportingAgent extends FeatureSwitch {
+  override val configName: String  = prefix + "ema-supporting-agents-enabled"
+  override val displayName: String = "EMA Supporting/Secondary Agents enabled"
+}

--- a/app/featureswitch/core/models/FeatureSwitch.scala
+++ b/app/featureswitch/core/models/FeatureSwitch.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package featureswitch.core.models
+
+trait FeatureSwitch {
+  val prefix: String = "feature-switch."
+  val configName: String
+  val displayName: String
+}

--- a/app/featureswitch/core/models/FeatureSwitchSetting.scala
+++ b/app/featureswitch/core/models/FeatureSwitchSetting.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package featureswitch.core.models
+
+import play.api.libs.json.{Json, OFormat}
+
+
+case class FeatureSwitchSetting(configName: String,
+                                displayName: String,
+                                isEnabled: Boolean)
+
+object FeatureSwitchSetting {
+
+  implicit val format: OFormat[FeatureSwitchSetting] = Json.format[FeatureSwitchSetting]
+
+}

--- a/app/services/CommonTaskListService.scala
+++ b/app/services/CommonTaskListService.scala
@@ -19,6 +19,7 @@ package services
 import cats.data.EitherT
 import config.AppConfig
 import connectors.errors.ApiError
+import featureswitch.core.config.SectionCompletedQuestion
 import models.get.{AllCISDeductions, CISSource}
 import models.mongo.JourneyAnswers
 import models.tasklist.SectionTitle.SelfEmploymentTitle
@@ -73,7 +74,7 @@ class CommonTaskListService @Inject()(appConfig: AppConfig,
         }
 
         cisTask(status)
-      case (_, true, _) => cisTask(if (appConfig.sectionCompletedQuestionEnabled) InProgress else Completed)
+      case (_, true, _) => cisTask(if (appConfig.isEnabled(SectionCompletedQuestion)) InProgress else Completed)
       case (_, _, _) => None
     }
   }

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ lazy val coverageSettings: Seq[Setting[?]] = {
     "config.*",
     "testOnly.*",
     "testOnlyDoNotUseInAppConf.*",
+    ".*featureswitch.*",
     "controllers.testOnly.*",
   )
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -32,6 +32,7 @@ play.http.errorHandler = "uk.gov.hmrc.play.bootstrap.backend.http.JsonErrorHandl
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
 play.modules.enabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"
 play.modules.enabled += "config.Module"
+play.modules.enabled += "featureswitch.core.config.FeatureSwitchingModule"
 
 # The application languages
 # ~~~~~

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -10,4 +10,9 @@
 # Failing to follow this rule may result in test routes deployed in production.
 
 # Add all the application routes to the prod.routes file
+
+GET        /income-tax-cis/test-only/api/feature-switches                             featureswitch.api.controllers.FeatureSwitchApiController.getFeatureSwitches()
++ nocsrf
+POST       /income-tax-cis/test-only/api/feature-switches                             featureswitch.api.controllers.FeatureSwitchApiController.updateFeatureSwitches()
+
 ->         /                          prod.Routes

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -17,7 +17,7 @@
 import sbt.*
 
 object AppDependencies {
-  private val bootstrapPlay30Version = "8.5.0"
+  private val bootstrapPlay30Version = "8.6.0"
   private val hmrcMongoPlay30Version = "2.3.0"
 
   private val jacksonAndPlayExclusions: Seq[InclusionRule] = Seq(

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-sbt run
+sbt -Dplay.http.router=testOnlyDoNotUseInAppConf.Routes run

--- a/test/actions/AuthorisedActionSpec.scala
+++ b/test/actions/AuthorisedActionSpec.scala
@@ -17,11 +17,13 @@
 package actions
 
 import config.AppConfig
+import featureswitch.core.config.EmaSupportingAgent
+import featureswitch.core.models.FeatureSwitch
 import models.authorisation.Enrolment.{Agent, Individual, Nino, SupportingAgent}
 import models.requests.AuthorisationRequest
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.stream.SystemMaterializer
-import org.scalamock.handlers.{CallHandler0, CallHandler4}
+import org.scalamock.handlers.{CallHandler1, CallHandler4}
 import play.api.http.{HeaderNames, Status => TestStatus}
 import play.api.mvc.Results._
 import play.api.mvc._
@@ -81,9 +83,9 @@ class AuthorisedActionSpec extends UnitTest
         .withIdentifier("MTDITID", mtdId)
         .withDelegatedAuthRule("mtd-it-auth-supp")
 
-    def mockMultipleAgentsSwitch(bool: Boolean): CallHandler0[Boolean] =
-      (mockAppConfig.emaSupportingAgentsEnabled _: () => Boolean)
-        .expects()
+    def mockMultipleAgentsSwitch(bool: Boolean): CallHandler1[FeatureSwitch, Boolean] =
+      (mockAppConfig.isEnabled(_: FeatureSwitch))
+        .expects(EmaSupportingAgent)
         .returning(bool)
         .anyNumberOfTimes()
 

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import featureswitch.core.config.SectionCompletedQuestion
+import org.scalamock.scalatest.MockFactory
+import play.api.Configuration
+import support.UnitTest
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+
+class AppConfigSpec extends UnitTest with MockFactory {
+
+  private val mockServicesConfig: ServicesConfig = mock[ServicesConfig]
+  private val mockConfiguration: Configuration = mock[Configuration]
+
+  private val appConfig = new AppConfigImpl(mockConfiguration, mockServicesConfig)
+
+  ".isEnabled(fs: FeatureSwitch)" when {
+    "value has not been saved to Sys.props" should {
+      "return the value from AppConfig" in {
+        (mockServicesConfig.getBoolean _).expects(SectionCompletedQuestion.configName).returns(false).once()
+        sys.props.get(SectionCompletedQuestion.configName) shouldBe None
+        appConfig.isEnabled(SectionCompletedQuestion) shouldBe false
+      }
+    }
+
+    "value has been saved to Sys.pros" should {
+      "return `true`" when {
+        "feature is enabled" in {
+          (mockServicesConfig.getBoolean _).expects(SectionCompletedQuestion.configName).never()
+          appConfig.enable(SectionCompletedQuestion)
+          sys.props.get(SectionCompletedQuestion.configName) shouldBe Some("true")
+          appConfig.isEnabled(SectionCompletedQuestion) shouldBe true
+        }
+      }
+
+      "return `false`" when {
+        "feature is disabled" in {
+          (mockServicesConfig.getBoolean _).expects(SectionCompletedQuestion.configName).never()
+          appConfig.disable(SectionCompletedQuestion)
+          sys.props.get(SectionCompletedQuestion.configName) shouldBe Some("false")
+          appConfig.isEnabled(SectionCompletedQuestion) shouldBe false
+        }
+      }
+    }
+  }
+
+}

--- a/test/config/AppConfigStub.scala
+++ b/test/config/AppConfigStub.scala
@@ -16,13 +16,21 @@
 
 package config
 
+import featureswitch.core.config.SectionCompletedQuestion
+import featureswitch.core.models.FeatureSwitch
 import org.scalamock.scalatest.MockFactory
 import play.api.Configuration
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 class AppConfigStub extends MockFactory {
 
-  def config(desHost: String = "localhost", environment: String = "test"): AppConfig = new AppConfigImpl(mock[Configuration], mock[ServicesConfig]) {
+  lazy val mockConfiguration = mock[Configuration]
+  lazy val mockServicesConfig = mock[ServicesConfig]
+
+  def config(desHost: String = "localhost",
+             environment: String = "test",
+             sectionCompletedQuestionEnabled: Boolean = false
+            ): AppConfig = new AppConfigImpl(mockConfiguration, mockServicesConfig) {
     private val wireMockPort = 11111
 
     private lazy val authorisationToken: String = "secret"
@@ -38,6 +46,10 @@ class AppConfigStub extends MockFactory {
     override lazy val desAuthorisationToken: String = "authorisation-token"
     override lazy val desEnvironment: String = "environment"
 
-    override lazy val sectionCompletedQuestionEnabled: Boolean = false
+    private def mockFeatureSwitchResponse(featureSwitch: FeatureSwitch, isEnabled: Boolean): Unit = {
+      sys.props.remove(featureSwitch.configName)
+      (mockServicesConfig.getBoolean(_: String)).expects(featureSwitch.configName).returning(isEnabled).anyNumberOfTimes()
+    }
+    mockFeatureSwitchResponse(SectionCompletedQuestion, isEnabled = sectionCompletedQuestionEnabled)
   }
 }

--- a/test/services/CommonTaskListServiceSpec.scala
+++ b/test/services/CommonTaskListServiceSpec.scala
@@ -17,7 +17,7 @@
 package services
 
 import common.CISSource.CONTRACTOR
-import config.{AppConfig, AppConfigImpl}
+import config.{AppConfig, AppConfigStub}
 import connectors.errors.{ApiError, SingleErrorBody}
 import models.get.{AllCISDeductions, CISSource}
 import models.mongo.JourneyAnswers
@@ -25,7 +25,6 @@ import models.tasklist.SectionTitle.SelfEmploymentTitle
 import models.tasklist.TaskStatus.{CheckNow, Completed, InProgress, NotStarted}
 import models.tasklist.TaskTitle.CIS
 import models.tasklist._
-import play.api.Configuration
 import play.api.libs.json.{JsObject, JsString, Json}
 import support.ControllerUnitTest
 import support.builders.CISDeductionsBuilder.aCISDeductions
@@ -34,7 +33,6 @@ import support.builders.GetPeriodDataBuilder.aGetPeriodData
 import support.mocks.{MockAuthorisedAction, MockCISDeductionsService, MockJourneyAnswersRepository}
 import support.providers.{AppConfigStubProvider, FakeRequestProvider}
 import uk.gov.hmrc.http.{HeaderCarrier, SessionId}
-import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import java.time.Instant
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -52,8 +50,6 @@ class CommonTaskListServiceSpec extends ControllerUnitTest
     val nino: String = "12345678"
     val taxYear: Int = 1234
     val mtditid: String = "dummyMtditid"
-
-    val appConfig: AppConfig = appConfigStub
 
     def service: CommonTaskListService = new CommonTaskListService(
       appConfig = appConfigStub,
@@ -178,10 +174,7 @@ class CommonTaskListServiceSpec extends ControllerUnitTest
     "HMRC data is omitted, or not latest, Journey Answers are not defined, and customer data exists" should {
       "return expected task list with 'InProgress' status if section completed feature switch is enabled" in new Test {
         override val service: CommonTaskListService = new CommonTaskListService(
-          appConfig = new AppConfigImpl(mock[Configuration], mock[ServicesConfig]) {
-            override lazy val cisFrontendBaseUrl: String = "http://localhost:9338"
-            override lazy val sectionCompletedQuestionEnabled: Boolean = true
-          },
+          appConfig = new AppConfigStub().config(sectionCompletedQuestionEnabled = true),
           cisDeductionsService = mockCISDeductionsService,
           journeyAnswersRepository = mockJourneyAnswersRepo
         )


### PR DESCRIPTION
### Description
This change allows the Feature Switch settings to be stored as Sys.props within the µService instance. This allows us to change whether features are enabled or disabled dynamically at will both locally and within QA/Staging.

This is achieved via the Frontend µService testOnly page that allows the enabling and disabling of switches.

### Checklist PR Reviewer
##### Before Reviewing
- [ ]  Have you pulled the branch down?
- [ ]  Have you assigned yourself to the PR?
- [ ]  Have you moved the task to “in review” on JIRA?
- [ ]  Have you checked to ensure all dependencies are up to date?
- [ ]  Have you checked to ensure its been rebased against the current version of main?

##### Whilst Reviewing
- [ ]  Have you run the tests?
- [ ]  Have you run the journey tests?
- [ ]  Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?

##### After Reviewing
- [ ]  Have you checked for merge conflicts or any changes in the current main that may affect the current pull request? i.e. does it need another rebase?
- [ ]  Have you checked to make sure there are no builds in the pipeline before you merge?
- [ ]  Have you moved the task to “in pipeline” on Jira?

### Checklist PR Raiser
##### Before creating PR
- [ ]  Have you run the tests?
- [ ]  Have you run the journey tests? (where applicable)
- [ ]  Have you addressed warnings where appropriate?
- [ ]  Have you rebased against the current version of main?
- [ ]  Have you checked code coverage isn’t lower than previously?

##### After PRs been raised
- [ ]  Have you checked the PR Builder passes?
